### PR TITLE
feat: Upgrade dependencies and  UGW adoption

### DIFF
--- a/mission-patient-list/approuter/package.json
+++ b/mission-patient-list/approuter/package.json
@@ -3,10 +3,10 @@
 	"version": "1.0.0",
 	"description": "Node.js based application router service for example application",
 	"engines": {
-		"node": "^20.0.0"
+		"node": "^22.0.0"
 	},
 	"dependencies": {
-		"@sap/approuter": "16.0.2"
+		"@sap/approuter": "21.4.0"
 	},
 	"scripts": {
 		"start": "node node_modules/@sap/approuter/approuter.js"

--- a/mission-patient-list/approuter/xs-app.json
+++ b/mission-patient-list/approuter/xs-app.json
@@ -5,7 +5,7 @@
       "source": "^/core(.*)$",
       "target": "$1",
       "service": "com.sap.health.fs",
-      "endpoint": "coreservice",
+      "endpoint": "hdsf_url_for_app",
       "httpMethods": [
         "POST",
         "OPTIONS",
@@ -16,7 +16,7 @@
       "source": "/core/(.*)$",
       "target": "$1",
       "service": "com.sap.health.fs",
-      "endpoint": "coreservice",
+      "endpoint": "hdsf_url_for_app",
       "authenticationType": "xsuaa"
     },
     {

--- a/mission-patient-list/apps/patientlist/package.json
+++ b/mission-patient-list/apps/patientlist/package.json
@@ -16,14 +16,14 @@
         ]
     },
     "dependencies": {
-        "openui5-fhir": "2.3.3"
+        "openui5-fhir": "2.4.0"
     },
     "devDependencies": {
-        "@sap/ui5-builder-webide-extension": "1.1.8",
-        "@ui5/cli": "2.14.13",
+        "@sap/ui5-builder-webide-extension": "1.1.9",
+        "@ui5/cli": "2.14.20",
         "bestzip": "2.2.1",
-        "eslint": "8.25.0",
+        "eslint": "8.57.1",
         "eslint-watch": "8.0.0",
-        "rimraf": "3.0.2"
+        "rimraf": "6.1.3"
     }
 }

--- a/mission-patient-list/apps/patientlist/xs-app.json
+++ b/mission-patient-list/apps/patientlist/xs-app.json
@@ -15,7 +15,7 @@
       "source": "^/core(.*)$",
       "target": "$1",
       "service": "com.sap.health.fs",
-      "endpoint": "coreservice",
+      "endpoint": "hdsf_url_for_app",
       "httpMethods": [
         "POST",
         "OPTIONS",
@@ -26,7 +26,7 @@
       "source": "/core/(.*)$",
       "target": "$1",
       "service": "com.sap.health.fs",
-      "endpoint": "coreservice",
+      "endpoint": "hdsf_url_for_app",
       "authenticationType": "xsuaa"
     },
     {

--- a/mission-patient-list/mta.yaml
+++ b/mission-patient-list/mta.yaml
@@ -1,7 +1,7 @@
 _schema-version: "3.1.0"
 ID: sap-health-example-mission
 description: SAP Health Example for Mission
-version: 4.0.0
+version: 5.0.0
 parameters:
   suffix: default
   deploy_mode: html5-repo

--- a/mission-patient-list/security/xs-security.json
+++ b/mission-patient-list/security/xs-security.json
@@ -19,7 +19,8 @@
    "oauth2-configuration": {
       "redirect-uris": [
          "https://*.cfapps.eu10.hana.ondemand.com/**",
-         "https://*.cfapps.eu10-004.hana.ondemand.com/**"
+         "https://*.cfapps.eu10-004.hana.ondemand.com/**",
+         "https://*.cfapps.eu10-005.hana.ondemand.com/**"
       ]
    },
    "role-templates":[


### PR DESCRIPTION
Upgraded the dependencies for security vulnerability With this release the minimum Node version required to build and deploy the app is 22 or higher. Adopted Unified Gateway Service Endpoints